### PR TITLE
cargo: add package description

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/kata-containers/dbs-snapshot"
 homepage = "https://github.com/kata-containers/dbs-snapshot"
+description = "A version tolerant state serialization and deserialization library"
 
 [lib]
 bench = false


### PR DESCRIPTION
crates.io requires it.