### PR TITLE
feat: support ppc64le and riscv64

### DIFF
--- a/.github/workflows/bvt.yaml
+++ b/.github/workflows/bvt.yaml
@@ -10,6 +10,9 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64, arm64, ppc64le, riscv64]
     steps:
       - uses: actions/checkout@v2
       - run: rustup install ${{ env.RUST_VERSION }} && rustup default ${{ env.RUST_VERSION }}
@@ -25,6 +28,9 @@ jobs:
   clippy:
     name: Clippy Check
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64, arm64, ppc64le, riscv64]
     steps:
       - uses: actions/checkout@v2
       - run: rustup install ${{ env.RUST_VERSION }} && rustup default ${{ env.RUST_VERSION }}
@@ -33,12 +39,18 @@ jobs:
   test:
     name: Run Unit Test
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64, arm64, ppc64le, riscv64]
     steps:
       - uses: actions/checkout@v2
       - run: rustup install ${{ env.RUST_VERSION }} && rustup default ${{ env.RUST_VERSION }}
       - run: make test
   bench:
     name: Run Benchmark Test
+    strategy:
+      matrix:
+        arch: [amd64, arm64, ppc64le, riscv64]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,12 @@ const BASE_MAGIC_ID: u64 = 0x0710_1984_8664_0000u64;
 #[cfg(target_arch = "aarch64")]
 const BASE_MAGIC_ID: u64 = 0x0710_1984_AAAA_0000u64;
 
+#[cfg(target_arch = "powerpc64")]
+const BASE_MAGIC_ID: u64 = 0x0710_1984_CC64_0000u64;
+
+#[cfg(target_arch = "riscv64")]
+const BASE_MAGIC_ID: u64 = 0x0710_1984_C564_0000u64;
+
 /// Error definitions for the Snapshot API.
 #[derive(Debug, thiserror::Error, displaydoc::Display, PartialEq)]
 pub enum Error {
@@ -326,6 +332,10 @@ mod tests {
         let good_magic_id = 0x0710_1984_8664_0001u64;
         #[cfg(target_arch = "aarch64")]
         let good_magic_id = 0x0710_1984_AAAA_0001u64;
+        #[cfg(target_arch = "powerpc64")]
+        let good_magic_id = 0x0710_1984_CC64_0001u64;
+        #[cfg(target_arch = "riscv64")]
+        let good_magic_id = 0x0710_1984_C564_0001u64;
 
         assert_eq!(get_format_version(good_magic_id).unwrap(), 1u16);
 
@@ -550,6 +560,10 @@ mod tests {
         let expected_err = Error::Crc64(0x1960_4E6A_A13F_6615);
         #[cfg(target_arch = "x86_64")]
         let expected_err = Error::Crc64(0x103F_8F52_8F51_20B1);
+        #[cfg(target_arch = "powerpc64")]
+        let expected_err = Error::Crc64(0x33D0_CCE5_DA3C_CCEA);
+        #[cfg(target_arch = "riscv64")]
+        let expected_err = Error::Crc64(0xFAC5_E225_5586_9011);
 
         let load_result: Result<(Test1, _), Error> =
             Snapshot::load(&mut snapshot_mem.as_slice(), 38, vm);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -53,6 +53,14 @@ fn test_hardcoded_snapshot_deserialization() {
         0xAA,
         #[cfg(target_arch = "aarch64")]
         0xAA,
+        #[cfg(target_arch = "powerpc64")]
+        0x64,
+        #[cfg(target_arch = "powerpc64")]
+        0xCC,
+        #[cfg(target_arch = "riscv64")]
+        0x64,
+        #[cfg(target_arch = "riscv64")]
+        0xC5,
         #[cfg(target_arch = "x86_64")]
         0x64,
         #[cfg(target_arch = "x86_64")]
@@ -75,10 +83,19 @@ fn test_hardcoded_snapshot_deserialization() {
         0xAA,
         #[cfg(target_arch = "aarch64")]
         0xAA,
+        #[cfg(target_arch = "powerpc64")]
+        0x64,
+        #[cfg(target_arch = "powerpc64")]
+        0xCC,
+        #[cfg(target_arch = "riscv64")]
+        0x64,
+        #[cfg(target_arch = "riscv64")]
+        0xC5,
         #[cfg(target_arch = "x86_64")]
         0x64,
         #[cfg(target_arch = "x86_64")]
-        0x86, 0x84, 0x19, 0x10, 0x07,
+        0x86,
+        0x84, 0x19, 0x10, 0x07,
         // Version 2 +
         0x02, 0x00,
         // `a` field +
@@ -129,6 +146,14 @@ fn test_invalid_format_version() {
         0xAA,
         #[cfg(target_arch = "aarch64")]
         0xAA,
+        #[cfg(target_arch = "powerpc64")]
+        0x64,
+        #[cfg(target_arch = "powerpc64")]
+        0xCC,
+        #[cfg(target_arch = "riscv64")]
+        0x64,
+        #[cfg(target_arch = "riscv64")]
+        0xC5,
         #[cfg(target_arch = "x86_64")]
         0x64,
         #[cfg(target_arch = "x86_64")]
@@ -156,6 +181,14 @@ fn test_invalid_format_version() {
         0xAA,
         #[cfg(target_arch = "aarch64")]
         0xAA,
+        #[cfg(target_arch = "powerpc64")]
+        0x64,
+        #[cfg(target_arch = "powerpc64")]
+        0xCC,
+        #[cfg(target_arch = "riscv64")]
+        0x64,
+        #[cfg(target_arch = "riscv64")]
+        0xC5,
         #[cfg(target_arch = "x86_64")]
         0x64,
         #[cfg(target_arch = "x86_64")]
@@ -185,6 +218,14 @@ fn test_invalid_data_version() {
         0xAA,
         #[cfg(target_arch = "aarch64")]
         0xAA,
+        #[cfg(target_arch = "powerpc64")]
+        0x64,
+        #[cfg(target_arch = "powerpc64")]
+        0xCC,
+        #[cfg(target_arch = "riscv64")]
+        0x64,
+        #[cfg(target_arch = "riscv64")]
+        0xC5,
         #[cfg(target_arch = "x86_64")]
         0x64,
         #[cfg(target_arch = "x86_64")]
@@ -211,6 +252,14 @@ fn test_invalid_data_version() {
         0xAA,
         #[cfg(target_arch = "aarch64")]
         0xAA,
+        #[cfg(target_arch = "powerpc64")]
+        0x64,
+        #[cfg(target_arch = "powerpc64")]
+        0xCC,
+        #[cfg(target_arch = "riscv64")]
+        0x64,
+        #[cfg(target_arch = "riscv64")]
+        0xC5,
         #[cfg(target_arch = "x86_64")]
         0x64,
         #[cfg(target_arch = "x86_64")]


### PR DESCRIPTION
Ref: https://github.com/dragonflyoss/nydus/pull/1510.
---
Add `BASE_MAGIC_ID` in ppc64le and riscv64 archs.