### PR TITLE
chore: bump versionize from 0.1.10 to 0.2.0 and rust version

### DIFF
--- a/.github/workflows/bvt.yaml
+++ b/.github/workflows/bvt.yaml
@@ -5,7 +5,7 @@ on:
       - main
   workflow_dispatch:
 env:
-  RUST_VERSION: 1.73.0
+  RUST_VERSION: 1.84.0
 jobs:
   build:
     name: Build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbs-snapshot"
-version = "1.5.1"
+version = "1.5.2"
 authors = [
     "Amazon Firecracker team <firecracker-devel@amazon.com>",
     "Kata Containers Developers",
@@ -18,7 +18,7 @@ bench = false
 
 [dependencies]
 libc = "0.2.117"
-versionize = "0.1.10"
+versionize = "0.2.0"
 versionize_derive = "0.1.5"
 thiserror = "1.0.32"
 displaydoc = "0.2.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,8 @@
 //! Each structure, union or enum is versioned separately and only needs to increment their version
 //! if a field is added or removed. For each state snapshot we define 2 versions:
 //!  - **the format version** which refers to the SnapshotHdr, CRC, or the representation of
-//! primitives types (currently we use versionize that uses serde bincode as a backend). The current
-//! implementation does not have any logic dependent on it.
+//!    primitives types (currently we use versionize that uses serde bincode as a backend). The current
+//!    implementation does not have any logic dependent on it.
 //!  - **the data version** which refers to the state.
 mod persist;
 use std::fmt::Debug;


### PR DESCRIPTION
To fix this dragonflyoss/nydus#1647, we need bump versionize here first.
Cargo-deny(v0.16.4) checks of fuse-backend-rs also reports an error as follows: 
```
error[unsound]: `serde` deserialization for `FamStructWrapper` lacks bound checks that could potentially lead to out-of-bounds memory access
   ┌─ /home/bravey/community/fuse-backend-rs/Cargo.lock:73:1
   │
73 │ vmm-sys-util 0.11.2 registry+https://github.com/rust-lang/crates.io-index
   │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unsound advisory detected
   │
   ├ ID: RUSTSEC-2024-0002
   ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0002
   ├ ## Impact
     
     An issue was discovered in the `FamStructWrapper::deserialize` implementation
     provided by the crate for `vmm_sys_util::fam::FamStructWrapper`, which can lead
     to out of bounds memory accesses. The deserialization does not check that the
     length stored in the header matches the flexible array length. Mismatch in the
     lengths might allow out of bounds memory access through Rust-safe methods.
     
     Impacted versions: >= 0.5.0
     
     ## Patches
     
     The issue was corrected in version 0.12.0 by inserting a check that verifies
     the lengths of compared flexible arrays are equal for any deserialized header
     and aborting deserialization otherwise. Moreover, the API was changed so that
     header length can only be modified through Rust-unsafe code. This ensures that
     users cannot trigger out-of-bounds memory access from Rust-safe code.
   ├ Announcement: https://github.com/advisories/GHSA-875g-mfp6-g7f9
   ├ Solution: Upgrade to >=0.12.0 (try `cargo update -p vmm-sys-util`)
   ├ vmm-sys-util v0.11.2
     └── versionize v0.1.10
         └── dbs-snapshot v1.5.1
             └── fuse-backend-rs v0.12.0
``` 
